### PR TITLE
Raise exception if download_request fails

### DIFF
--- a/app/fireball.py
+++ b/app/fireball.py
@@ -378,6 +378,7 @@ def download_s3(uri, filename):
 def download(url, filename):
     try:
         download_request = requests.get(url)
+        download_request.raise_for_status()
         with open(filename, 'wb') as file:
             file.write(download_request.content)
         return True


### PR DESCRIPTION
Encountered an issue where the `download()` method had downloaded and saved an empty cover-page as the `requests.get(url)` call failed. 

Calling `raise_for_status()` will ensure an exception is thrown for non-2xx which will bubble the failure up.